### PR TITLE
Setup CI/CD pipeline and build project

### DIFF
--- a/intellinews/src/App.tsx
+++ b/intellinews/src/App.tsx
@@ -89,7 +89,7 @@ function App() {
         loadArticles();
       }
     }
-  }, [configuration.feeds, configuration.topics]);
+  }, [configuration.feeds, configuration.topics, loading]);
 
   // Load articles on mount and when feeds change
   useEffect(() => {


### PR DESCRIPTION
Add 'loading' to `useCallback` dependency array to fix CI build failure.

The CI environment treats ESLint warnings as errors. The `react-hooks/exhaustive-deps` rule flagged a missing 'loading' dependency in a `useCallback` hook, causing the build to fail. This change resolves the ESLint error and allows the build to pass.