### PR TITLE
Fix JSON parsing error on page load

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,8 +38,8 @@ coverage/
 .nyc_output/
 
 # Other projects
-backend/
-frontend/
+# backend/ - needed for integrated build
+# frontend/ - needed for integrated build
 
 # Documentation
 *.md

--- a/DOCKER_BUILD_FIX.md
+++ b/DOCKER_BUILD_FIX.md
@@ -1,0 +1,103 @@
+# Docker Build Fix für CI/CD Pipeline
+
+## Problem
+
+Der GitHub Actions CI/CD Build schlug mit folgendem Fehler fehl:
+
+```
+#12 [7/8] COPY backend/ ./backend/
+#12 ERROR: failed to calculate checksum of ref: "/backend": not found
+```
+
+## Root Cause
+
+Der Fehler trat auf, weil:
+
+1. **`.dockerignore` Ausschluss**: Die `.dockerignore` Datei enthielt `backend/` und `frontend/` in der Ausschlussliste
+2. **Fehlender Build-Kontext**: Docker konnte diese Verzeichnisse nicht sehen, obwohl das Dockerfile sie kopieren wollte
+3. **Inkonsistente Konfiguration**: Das Dockerfile wurde geändert, um `backend/` zu verwenden, aber die `.dockerignore` blockierte den Zugriff
+
+## Solution
+
+### 1. .dockerignore korrigiert
+
+```diff
+# Other projects
+- backend/
+- frontend/
++ # backend/ - needed for integrated build
++ # frontend/ - needed for integrated build
+```
+
+### 2. Vollständige Lösung
+
+Die Lösung besteht aus mehreren Komponenten:
+
+#### A. Dockerfile (bereits korrigiert)
+```dockerfile
+# Copy backend
+COPY backend/ ./backend/
+RUN cd backend && npm ci
+
+# Start the backend server
+CMD ["node", "backend/server.js"]
+```
+
+#### B. Backend Server (bereits erweitert)
+- Serviert statische React-Dateien
+- Stellt alle API-Endpoints bereit
+- Behandelt React Router korrekt
+
+#### C. .dockerignore (jetzt korrigiert)
+- Erlaubt Zugriff auf `backend/` und `frontend/` Verzeichnisse
+- Behält andere Ausschlüsse bei
+
+## Verifikation
+
+Der CI/CD Build sollte jetzt erfolgreich durchlaufen:
+
+1. ✅ `npm ci` - Abhängigkeiten installieren
+2. ✅ `npm run build` - React-App bauen
+3. ✅ `npm test` - Tests durchführen
+4. ✅ `docker build` - Docker Image erstellen
+
+## Build-Ablauf
+
+```bash
+# 1. React-App wird gebaut
+cd intellinews && npm ci && npm run build
+
+# 2. Backend wird kopiert und konfiguriert
+COPY backend/ ./backend/
+RUN cd backend && npm ci
+
+# 3. Backend Server startet und serviert:
+#    - React-App (statische Dateien)
+#    - API-Endpoints (/api/*)
+#    - React Router (catch-all)
+```
+
+## Testen
+
+Lokal testen:
+```bash
+# Build testen
+docker build -t intellinews-test .
+
+# Container starten
+docker run -p 8080:8080 intellinews-test
+
+# Testen
+curl http://localhost:8080/api/health
+# Should return JSON, not HTML
+```
+
+## Deployment
+
+Nach dem Fix sollte der GitHub Actions Build erfolgreich durchlaufen und die App korrekt deployed werden.
+
+Die finale Architektur:
+- **Ein Container** mit integriertem Frontend und Backend
+- **Ein Server** (`backend/server.js`) der alles serviert
+- **Korrekte API-Responses** (JSON statt HTML)
+- **Funktionierendes React Router**

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,12 @@ RUN npm install
 COPY intellinews/ ./intellinews/
 RUN cd intellinews && npm ci && npm run build
 
-# Copy server
-COPY server.js ./
+# Copy backend
+COPY backend/ ./backend/
+RUN cd backend && npm ci
 
 # Expose port
 EXPOSE 8080
 
-# Start server
-CMD ["node", "server.js"]
+# Start the backend server
+CMD ["node", "backend/server.js"]

--- a/JSON_PARSING_ERROR_FIX.md
+++ b/JSON_PARSING_ERROR_FIX.md
@@ -1,0 +1,69 @@
+# JSON Parsing Error Fix
+
+## Problem
+
+Die React-App erhielt den Fehler: `Unexpected token '<', "<!doctype "... is not valid JSON`
+
+## Root Cause
+
+Der Fehler trat auf, weil:
+
+1. **Falsche Server-Konfiguration**: Das Dockerfile startete den falschen Server (`server.js` statt `backend/server.js`)
+2. **Fehlende API-Endpoints**: Der einfache `server.js` hatte nur einen `/health` Endpoint, aber die React-App rief `/api/health` auf
+3. **Fehlende statische Dateien**: Der `backend/server.js` hatte keine Konfiguration zum Servieren der React-App
+
+## Solution
+
+### 1. Dockerfile korrigiert
+
+```dockerfile
+# Vorher:
+CMD ["node", "server.js"]
+
+# Nachher:
+CMD ["node", "backend/server.js"]
+```
+
+### 2. Backend Server erweitert
+
+- **Static File Serving hinzugefügt**: Serviert jetzt die React-App Dateien aus `../intellinews/build/`
+- **Catch-all Route**: Alle nicht-API Routes werden an React weitergeleitet
+- **Korrekte API-Endpoints**: `/api/health` und alle anderen API-Endpoints sind verfügbar
+
+### 3. Änderungen in `backend/server.js`
+
+```javascript
+// Static file serving
+app.use(express.static(path.join(__dirname, '../intellinews/build')));
+
+// Catch-all handler für React Router
+app.get('*', (req, res) => {
+  if (req.path.startsWith('/api/')) {
+    // API 404 handling
+    return res.status(404).json({ error: 'Endpoint not found' });
+  }
+  
+  // Serve React app
+  res.sendFile(path.join(__dirname, '../intellinews/build/index.html'));
+});
+```
+
+## Testen
+
+Nach dem Fix sollte:
+1. Die React-App korrekt laden
+2. Der `/api/health` Endpoint JSON zurückgeben
+3. Alle anderen API-Endpoints funktionieren
+4. React Router korrekt funktionieren
+
+## Deployment
+
+```bash
+# Container neu bauen
+docker build -t intellinews .
+
+# Container starten
+docker run -p 8080:8080 intellinews
+```
+
+Die App ist dann unter `http://localhost:8080` erreichbar.


### PR DESCRIPTION
Configure Docker to run the correct backend server and serve the React app to fix JSON parsing errors.

The React frontend expected JSON from `/api/health`, but the Docker container was configured to run a minimal `server.js` that only had a `/health` endpoint and didn't serve the React build. This resulted in the frontend receiving an HTML error page instead of JSON, leading to the "Unexpected token '<', "<!doctype "... is not valid JSON" error. The fix ensures the full backend (`backend/server.js`) is run, which now also serves the React static files and handles API routes correctly.